### PR TITLE
feat: add an examples folder and the build instructions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,29 +4,35 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const zee_module = b.addModule("zee", .{
-        .root_source_file = b.path("src/root.zig"),
-    });
-
-    const lib = b.addStaticLibrary(.{
-        .name = "zeevm",
-        .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-
-    lib.root_module.addImport("zee", zee_module);
-
     const lib_unit_tests = b.addTest(.{
         .root_source_file = b.path("src/test.zig"),
         .target = target,
         .optimize = optimize,
     });
 
-    b.installArtifact(lib);
-
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_lib_unit_tests.step);
+
+    // Examples
+    const examples_step = b.step("example", "Run examples");
+
+    const example = b.addExecutable(.{
+        .name = "example",
+        .root_source_file = b.path("examples/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const zee_stack_module = b.addModule("zee_stack", .{
+        .root_source_file = b.path("src/lib/stack.zig"),
+    });
+
+    example.root_module.addImport("zee_stack", zee_stack_module);
+
+    const example_run = b.addRunArtifact(example);
+    examples_step.dependOn(&example_run.step);
+
+    b.default_step.dependOn(examples_step);
 }

--- a/examples/main.zig
+++ b/examples/main.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+const Stack = @import("zee_stack");
+
+pub fn main() !void {
+    std.debug.print("Hello World!\n", .{});
+
+    var stack = Stack{};
+    try stack.push(32);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,0 @@
-const std = @import("std");
-
-pub fn main() void {
-    std.debug.print("Coming soon");
-}


### PR DESCRIPTION
Add an `examples` folder and the instruction to build in the build.zig file.

This can be use to demonstrate how to use the lib in an project.